### PR TITLE
Update TopasScriptGenerator.py

### DIFF
--- a/TopasOpt/TopasScriptGenerator.py
+++ b/TopasOpt/TopasScriptGenerator.py
@@ -240,7 +240,7 @@ class generate_topas_script_generator:
             for line in f:
                 line = line.replace('\n', '')  # remove new line characters
                 CommentLine = False
-                if (not line == '') and line.lstrip()[0] == '#':
+                if (not line.lstrip() == '') and line.lstrip()[0] == '#':
                     CommentLine = True
 
                 if not CommentLine:  # avoid doing anything silly to commented lines


### PR DESCRIPTION
fixes the case where a line contains nothing but spaces, which was previously crashing.